### PR TITLE
Missing FirstAired attribute in BasicEpisode

### DIFF
--- a/lib/Adrenth/Thetvdb/Model/BasicEpisode.php
+++ b/lib/Adrenth/Thetvdb/Model/BasicEpisode.php
@@ -36,6 +36,7 @@ class BasicEpisode extends ValueObject
             'dvdSeason',
             'episodeName',
             'overview',
+            'firstAired'
         ];
     }
 }


### PR DESCRIPTION
firstAired seems to be missing from BasicEpisode while this is returned in the response.