### PR TITLE
Ensures Guzzle doesn't throw exceptions, but returns a response

### DIFF
--- a/lib/Adrenth/Thetvdb/Client.php
+++ b/lib/Adrenth/Thetvdb/Client.php
@@ -235,6 +235,8 @@ class Client implements ClientInterface
             $headers['Accept'] = 'application/vnd.thetvdb.v' . $this->version;
         }
 
+        $options['http_errors'] = false;
+
         return array_merge_recursive(
             [
                 'headers' => $headers,


### PR DESCRIPTION
While testing the API with wrong data, I noticed that on my Guzzle version (GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.0.13-1~dotdeb+8.1) I got a 404 HTTP exception  straight from Guzzle instead of the expected errors (see excerpt below):

```
{
            "type": "GuzzleHttp\\Exception\\ClientException",
            "code": 404,
            "message": "Client error: `GET https://api.thetvdb.com/series/0` resulted in a `404 Not Found` response:\n{\n  \"Error\": \"ID: 0 not found\"\n}\n",
            "file": "./vendor/guzzlehttp/guzzle/src/Exception/RequestException.php",
            "line": 113,
            "trace": [
                "#0 ./vendor/guzzlehttp/guzzle/src/Middleware.php(65): GuzzleHttp\\Exception\\RequestException::create(Object(GuzzleHttp\\Psr7\\Request), Object(GuzzleHttp\\Psr7\\Response))",
                "#1 ./vendor/guzzlehttp/promises/src/Promise.php(203): GuzzleHttp\\Middleware::GuzzleHttp\\{closure}(Object(GuzzleHttp\\Psr7\\Response))",
                "#2 ./vendor/guzzlehttp/promises/src/Promise.php(156): GuzzleHttp\\Promise\\Promise::callHandler(1, Object(GuzzleHttp\\Psr7\\Response), Array)",
                "#3 ./vendor/guzzlehttp/promises/src/TaskQueue.php(47): GuzzleHttp\\Promise\\Promise::GuzzleHttp\\Promise\\{closure}()",
                "#4 ./vendor/guzzlehttp/promises/src/Promise.php(246): GuzzleHttp\\Promise\\TaskQueue->run(true)",
                "#5 ./vendor/guzzlehttp/promises/src/Promise.php(223): GuzzleHttp\\Promise\\Promise->invokeWaitFn()",
                "#6 ./vendor/guzzlehttp/promises/src/Promise.php(266): GuzzleHttp\\Promise\\Promise->waitIfPending()",
                "#7 ./vendor/guzzlehttp/promises/src/Promise.php(225): GuzzleHttp\\Promise\\Promise->invokeWaitList()",
                "#8 ./vendor/guzzlehttp/promises/src/Promise.php(62): GuzzleHttp\\Promise\\Promise->waitIfPending()",
                "#9 ./vendor/guzzlehttp/guzzle/src/Client.php(129): GuzzleHttp\\Promise\\Promise->wait()",
                "#10 ./vendor/guzzlehttp/guzzle/src/Client.php(87): GuzzleHttp\\Client->request('get', '/series/0', Array)",
                "#11 ./vendor/adrenth/thetvdb2/lib/Adrenth/Thetvdb/Client.php(206): GuzzleHttp\\Client->__call('get', Array)",
                "#12 ./vendor/adrenth/thetvdb2/lib/Adrenth/Thetvdb/Client.php(177): Adrenth\\Thetvdb\\Client->performApiCall('get', '/series/0', Array)",
                "#13 ./vendor/adrenth/thetvdb2/lib/Adrenth/Thetvdb/Extension/SeriesExtension.php(48): Adrenth\\Thetvdb\\Client->performApiCallWithJsonResponse('get', '/series/0')",
                "#14 ./src/Slim/Controllers/SeriesController.php(500): Adrenth\\Thetvdb\\Extension\\SeriesExtension->get('test')",

            ]
        }
```

Looking at the Guzzle doc (http://docs.guzzlephp.org/en/latest/request-options.html#http-errors) there is an option to turn throwing exceptions off.

This commit adds that option (and fixes the issue for me).