### PR TITLE
Upgrade PHPUnit to be compatible with PHP7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^7.0",
         "symfony/var-dumper": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.17"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="true"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
     <testsuites>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,8 +11,9 @@ use Adrenth\Thetvdb\Extension\LanguagesExtension;
 use Adrenth\Thetvdb\Extension\SearchExtension;
 use Adrenth\Thetvdb\Extension\UpdatesExtension;
 use Adrenth\Thetvdb\Extension\UsersExtension;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /** @var Client */
     protected $client;


### PR DESCRIPTION
# Changed log

- Since this package requires `php-7.1` version at least, it should let the `PHPUnit` version require `^7.0` version.
And it can be compatible with `PHP-7.1+` version.
- Removing the `syntaxCheck` attribute setting to resolve following message:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 13:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.

```